### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "name": "Clarkie",
     "email": "andrew.t.clarke@gmail.com"
   },
-  "contributors": [{
-    "name": "Dung Phung",
-    "email": "dkphung@ucdavis.edu"
-  }],
+  "contributors": [
+    {
+      "name": "Dung Phung",
+      "email": "dkphung@ucdavis.edu"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/clarkie/grunt-mssql.git"
@@ -18,10 +20,12 @@
   "bugs": {
     "url": "https://github.com/clarkie/grunt-mssql/issues"
   },
-  "licenses": [{
-    "type": "MIT",
-    "url": "https://github.com/clarkie/grunt-mssql/blob/master/LICENSE-MIT"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/clarkie/grunt-mssql/blob/master/LICENSE-MIT"
+    }
+  ],
   "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.8.0"
@@ -36,7 +40,7 @@
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
